### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   frontend-tests:
     name: Frontend Tests


### PR DESCRIPTION
Potential fix for [https://github.com/timhughes/fishki/security/code-scanning/1](https://github.com/timhughes/fishki/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to restrict the `GITHUB_TOKEN` permissions. Based on the workflow's purpose (running frontend tests), it likely does not require any write permissions. Setting `contents: read` at the workflow level is sufficient and adheres to the principle of least privilege. This will apply the permissions to all jobs in the workflow unless overridden by job-specific `permissions` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
